### PR TITLE
chore: fix style guideline link in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Please include a summary of the change. Please also include relevant motivation 
 
 # Checklist:
 
-- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
+- [ ] My code follows the [style guidelines](https://github.com/dimaqq/sdcore-amf-k8s-operator/blob/main/CONTRIBUTING.md) of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that validate the behaviour of the software


### PR DESCRIPTION
# Description

Fix style guideline link in the PR template.

`/foo` is rendered as a link to `github.com/foo`.
an absolute link solves the problem, and I couldn't find a good relative link that actually works.